### PR TITLE
Use tags for services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - frontend
 
   db:
-    image: postgres
+    image: postgres:13
     restart: always
     environment:
       - POSTGRES_USER=${dbUser}
@@ -72,5 +72,5 @@ services:
       - db
 
   redis:
-    image: redis
+    image: redis:6
     restart: always


### PR DESCRIPTION
Without tags, pulling images later may pull new major releases with breaking change.

By using a tag, we ensure to stay on the same major release, with less risk of having breaking changes.