### PR TITLE
Scan images based on cron schedule

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.8
 
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.12/supercronic-linux-amd64 \
+    SUPERCRONIC=supercronic-linux-amd64 \
+    SUPERCRONIC_SHA1SUM=048b95b48b708983effb2e5c935a1ef8483d9e3e
 # system packages installation
 
 RUN apt update && apt install -y curl nfs-common cifs-utils libopenblas-dev libmagickwand-dev libheif-dev libmagic1 ufraw-batch libboost-all-dev libxrender-dev liblapack-dev git bzip2 cmake build-essential libsm6 libglib2.0-0 libgl1-mesa-glx --no-install-recommends
@@ -15,6 +18,14 @@ RUN curl -SL https://s3.eu-central-1.amazonaws.com/ownphotos-deploy/im2txt_data.
 RUN curl -SL https://download.pytorch.org/models/resnet152-b121ed2d.pth -o /root/.cache/torch/hub/checkpoints/resnet152-b121ed2d.pth
 RUN pip install torch==1.8.0+cpu torchvision==0.9.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 RUN pip install -v --install-option="--no" --install-option="DLIB_USE_CUDA" --install-option="--no" --install-option="USE_AVX_INSTRUCTIONS" --install-option="--no" --install-option="USE_SSE4_INSTRUCTIONS" dlib
+
+# install supercronic for cron scheduling
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
+    && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+    && chmod +x "$SUPERCRONIC" \
+    && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+    && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+
 # actual project
 ARG DEBUG
 WORKDIR /code

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -14,6 +14,16 @@ echo "Running backend server..."
 
 python manage.py rqworker default 2>&1 | tee /logs/rqworker.log &
 
+echo "Installing crontab..."
+
+if [ -z "$IMAGE_SCAN_SCHEDULE" ]
+then
+    IMAGE_SCAN_SCHEDULE="0 */6 * * *"
+fi
+
+echo "$IMAGE_SCAN_SCHEDULE python3 manage.py scan >/dev/null 2>&1" > crontab
+supercronic crontab &
+
 if [ "$DEBUG" = 1 ]
 then
     echo "develompent backend starting"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,7 @@ services:
       - TIME_ZONE=${timeZone}
       - WEB_CONCURRENCY=${gunniWorkers}
       - SKIP_PATTERNS=${skipPatterns}
+      - IMAGE_SCAN_SCHEDULE=${imageScanSchedule}
       - DEBUG=0
 
     # Wait for Postgres

--- a/librephotos.env
+++ b/librephotos.env
@@ -61,6 +61,9 @@ dbUser=docker
 # The password used by the database.
 dbPass=AaAa1234
 
+# Cron style syntax for scheduling the photo scanning, default is every 6 hours
+imageScanSchedule=0 */6 * * *
+
 # Number of workers, which take care of the request to the api. This setting can dramatically affect the ram usage.
 # A positive integer generally in the 2-4 x $(NUM_CORES) range. 
 # You’ll want to vary this a bit to find the best for your particular workload.


### PR DESCRIPTION
* Simple cron task on container to scan images using supercronic, using the method documented here: https://github.com/LibrePhotos/librephotos/issues/25 without having to affect the docker host (i.e. the container handles it's own schedule)

Ideally this would be handled through a pool of jobs which are picked up by a worker, but I'm not familiar enough with Django to build that out. Until then, this is a simple solution to https://github.com/LibrePhotos/librephotos/issues/235 for anyone using the Docker installation of Librephotos