### PR TITLE
Change bind IP address from container name to any

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -17,8 +17,8 @@ python manage.py rqworker default 2>&1 | tee /logs/rqworker.log &
 if [ "$DEBUG" = 1 ]
 then
     echo "develompent backend starting"
-    gunicorn --worker-class=gevent --timeout 36000 --reload --bind backend:8001 --log-level=info ownphotos.wsgi 2>&1 | tee /logs/gunicorn_django.log
+    gunicorn --worker-class=gevent --timeout 36000 --reload --bind 0.0.0.0:8001 --log-level=info ownphotos.wsgi 2>&1 | tee /logs/gunicorn_django.log
 else
     echo "production backend starting"
-    gunicorn --worker-class=gevent --timeout 3600 --bind backend:8001 --log-level=info ownphotos.wsgi 2>&1 | tee /logs/gunicorn_django.log
+    gunicorn --worker-class=gevent --timeout 3600 --bind 0.0.0.0:8001 --log-level=info ownphotos.wsgi 2>&1 | tee /logs/gunicorn_django.log
 fi


### PR DESCRIPTION
In attempt to get LibrePhotos running in a docker swarm environment, I noticed I was not able to get the backend container to run. I was receiving an error that the gunicorn could not bind to backend:8001.

This is due to the DNS resolution in docker swarm not mapping directly to the IP address of the container as multiple replicas may be present. In order to correct this, the container can simply be bound to any available IP address. If this behavior is undesired, perhaps this could be changed to an environment variable instead.

After making the change, I was able to run LibrePhotos in docker swarm without issue.