### PR TITLE
#310: Add DEFAULT_FAVORITE_MIN_RATING to env file

### DIFF
--- a/librephotos.env
+++ b/librephotos.env
@@ -71,6 +71,10 @@ gunniWorkers=2
 # Each worker needs 800MB of RAM. Change at your own will. Default is 1.
 HEAVYWEIGHT_PROCESS=1
 
+# Default minimum rating to interpret as favorited. This default value is used when creating a new user.
+# Users can change this in their settings (Dashboards > Library).
+DEFAULT_FAVORITE_MIN_RATING=2
+
 # ---------------------------------------------------------------------------------------------
 
 # If you are not a developer ignore the following parameters: you will never need them.

--- a/librephotos.env
+++ b/librephotos.env
@@ -73,7 +73,7 @@ HEAVYWEIGHT_PROCESS=1
 
 # Default minimum rating to interpret as favorited. This default value is used when creating a new user.
 # Users can change this in their settings (Dashboards > Library).
-DEFAULT_FAVORITE_MIN_RATING=2
+DEFAULT_FAVORITE_MIN_RATING=4
 
 # ---------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Site managers can set a default favorite min rating for new users through an environment variable. This PR makes that option visible in the checked-in .env file template.