### PR TITLE
Reduce the number of stages

### DIFF
--- a/backend/dependencies/Dockerfile
+++ b/backend/dependencies/Dockerfile
@@ -1,96 +1,113 @@
-FROM ubuntu:hirsute
+FROM ubuntu:20.04
 # system packages installation
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install python
-RUN apt-get update \
-  && apt-get install -y python3-pip python3-dev \
-  && cd /usr/local/bin \
-  && ln -s /usr/bin/python3 python \
-  && pip3 install --upgrade pip
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+		build-essential \
+		bzip2 \
+		cifs-utils \
+		curl \
+		ffmpeg \
+		git \
+		libboost-all-dev \
+		libcfitsio-dev \ 
+		libexif-dev \
+		libexpat-dev \
+		libexpat1-dev \ 
+		libgif-dev \
+		libgl1-mesa-glx \
+		libglib2.0-dev \
+		libgsf-1-dev \ 
+		libheif-dev \
+		libimage-exiftool-perl \
+		libimagequant-dev \
+		libjpeg-dev \
+		liblapack-dev \
+		liblcms2-dev \
+		libmagic1 \
+		libopenblas-dev \
+		libopenexr-dev \ 
+		liborc-dev \
+		libpng-dev \
+		libpq-dev \
+		libraw-dev \
+		librsvg2-dev \
+		libsm6 \
+		libtiff5-dev \ 
+		libtool \ 
+		libtool-bin \
+		libwebp-dev \
+		libxrender-dev \
+		nfs-common \
+		pkg-config \ 
+		python3-dev \
+		python3-pip \
+		swig \
+		unzip && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN apt update && apt install -y ffmpeg swig cmake libimage-exiftool-perl curl nfs-common cifs-utils libopenblas-dev libheif-dev libmagic1 libraw-dev libboost-all-dev libxrender-dev liblapack-dev git bzip2 cmake build-essential libsm6 libglib2.0-dev libgl1-mesa-glx libpq-dev libexpat-dev \
-	librsvg2-dev \
-	libpng-dev \
-	libgif-dev \
-	libjpeg-dev \
-	libexif-dev \
-	liblcms2-dev \
-	liborc-dev \
-	pkg-config \ 
-	libexpat1-dev \ 
-	libtiff5-dev \ 
-	libgsf-1-dev \ 
-	libopenexr-dev \ 
-	libcfitsio-dev \ 
-	libimagequant-dev \
-	libtool \ 
-	libtool-bin \
-	wget \
-	libwebp-dev --no-install-recommends
+RUN pip3 install torch==1.9.1 torchvision==0.10.1 pyvips==2.1.15 cmake==3.21.2
+
 
 #Build and install libraw
-RUN git clone https://github.com/LibRaw/LibRaw
-RUN ls
-WORKDIR /LibRaw
-RUN autoreconf --install
-RUN ./configure
-RUN make
-RUN make install
+WORKDIR /tmp/builds
+RUN git clone https://github.com/LibRaw/LibRaw && \
+	cd LibRaw && \ 
+	autoreconf --install && \
+	./configure && \
+	make && \
+	make install
 
 #Build and install imagemagick
-WORKDIR /
-RUN mkdir /imagemagick
-RUN curl -SL https://www.imagemagick.org/download/ImageMagick.tar.gz | tar -zxC /imagemagick
-WORKDIR /imagemagick/ImageMagick-7.1.0-5
-RUN ./configure --with-modules
-RUN make install
-RUN ldconfig /usr/local/lib
+WORKDIR /tmp/builds
+ARG IMAGEMAGICK_VERSION=7.1.0-5
+RUN curl -SL https://www.imagemagick.org/download/releases/ImageMagick-${IMAGEMAGICK_VERSION}.tar.gz | tar -zx && \
+	cd ImageMagick-${IMAGEMAGICK_VERSION} && \
+	./configure --with-modules && \
+	make install && \
+	ldconfig /usr/local/lib
 
 # Build and install libvips
+WORKDIR /tmp/builds
 ARG VIPSVERSION=8.11.0
-ARG VIPSURL=https://github.com/libvips/libvips/releases/download
-WORKDIR /usr/local/src
-RUN wget ${VIPSURL}/v${VIPSVERSION}/vips-${VIPSVERSION}.tar.gz \ 
-	&& tar xzf vips-${VIPSVERSION}.tar.gz \ 
+RUN curl -SL https://github.com/libvips/libvips/releases/download/v${VIPSVERSION}/vips-${VIPSVERSION}.tar.gz | tar -xz \ 
 	&& cd vips-${VIPSVERSION} \ 
 	&& ./configure \ 
 	&& make V=0 \ 
 	&& make install \ 
 	&& ldconfig
 
-# pre trained models download
-WORKDIR /data_models
-RUN mkdir -p /root/.cache/torch/hub/checkpoints/
-
-RUN curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/places365.tar.gz | tar -zxC /data_models/
-RUN curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/im2txt.tar.gz | tar -zxC /data_models/
-RUN curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/clip-embeddings.tar.gz | tar -zxC /data_models/
-RUN curl -SL https://download.pytorch.org/models/resnet152-b121ed2d.pth -o /root/.cache/torch/hub/checkpoints/resnet152-b121ed2d.pth
-
-RUN pip install torch torchvision
-
-RUN pip3 install pyvips
-
 # Build and install dlib
-WORKDIR /
-RUN git clone https://github.com/davisking/dlib.git && \
-    mkdir /dlib/build && \
-    cd /dlib/build && \
+WORKDIR /tmp/builds
+RUN git clone --depth 1 --branch 'v19.22' https://github.com/davisking/dlib.git && \
+    mkdir dlib/build && \
+    cd dlib/build && \
     cmake .. -DDLIB_USE_CUDA=0 -DUSE_AVX_INSTRUCTIONS=0 -DLIB_NO_GUI_SUPPORT=0 && \
     cmake --build . && \
-    cd /dlib && \
-    python setup.py install --no USE_AVX_INSTRUCTIONS --no DLIB_USE_CUDA --no USE_SSE4_INSTRUCTIONS  
+    cd /tmp/builds/dlib && \
+    python3 setup.py install --no USE_AVX_INSTRUCTIONS --no DLIB_USE_CUDA --no USE_SSE4_INSTRUCTIONS  
 
 #Build and install faiss. Needs to be build for ARM 
-WORKDIR /faiss
-RUN git clone https://github.com/facebookresearch/faiss.git /faiss
-RUN cmake -B build . -DCMAKE_BUILD_TYPE=Release -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=ON -DFAISS_OPT_LEVEL=generic 
-RUN make -C build -j4 faiss
-RUN make -C build -j4 swigfaiss
-RUN (cd build/faiss/python && python setup.py install)
-# install unzip
-RUN apt install -y unzip
-# unzip faiss to actually installed it...
-RUN unzip /usr/local/lib/python3.9/dist-packages/faiss*.egg -d /usr/local/lib/python3.9/dist-packages/
+WORKDIR /tmp/builds
+RUN git clone --depth 1 --branch 'v1.7.1' https://github.com/facebookresearch/faiss.git && \
+	cd faiss  && \
+	cmake -B build . -DCMAKE_BUILD_TYPE=Release -DFAISS_ENABLE_GPU=OFF -DFAISS_ENABLE_PYTHON=ON -DFAISS_OPT_LEVEL=generic  && \
+	make -C build -j4 faiss && \
+	make -C build -j4 swigfaiss && \
+	cd build/faiss/python && \
+	python3 setup.py install && \
+	unzip /usr/local/lib/python3.8/dist-packages/faiss*.egg -d /usr/local/lib/python3.8/dist-packages/
+
+# pre trained models download
+WORKDIR /data_models
+
+RUN mkdir -p /root/.cache/torch/hub/checkpoints/ && \
+	curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/places365.tar.gz | tar -zxC /data_models/ && \
+	curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/im2txt.tar.gz | tar -zxC /data_models/ && \
+	curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/clip-embeddings.tar.gz | tar -zxC /data_models/ && \
+	curl -SL https://download.pytorch.org/models/resnet152-b121ed2d.pth -o /root/.cache/torch/hub/checkpoints/resnet152-b121ed2d.pth
+
+RUN rm -fr /tmp/*


### PR DESCRIPTION
Hi LibrePhotos team,

With this MR I'd like to contribute with a Dockerfile that reduces the number of stages from 40 to 13. I made some decisions when reducing the stages:

- Use a stable LTS release of Ubuntu as base image
- Use only `curl` and not `wget`
- Create one stage per library to be installed
- Use `/tmp`, and later delete the content, for the building process
- I pinned versions of software
- `cmake` is installed via `pip`
- I kept the build of the libraries. I am pretty sure that you have a good reason for building them instead of using a pre-compiled version

Unfortunately this does not reduce significantly the size of the image, but I hope it makes it easier to maintain in the future.