### PR TITLE
Make containers renamable from .env file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: default build run shell
+.PHONY: default build run shell rename
 
+include librephotos.env
 DOCKER_TAG ?= ownphotos-backend
+REPLACE_NAMES=sed 's/__backend_name__/$(BACKEND_HOST)/g; s/__frontend_name__/$(FRONTEND_HOST)/g; s/__proxy_name__/$(PROXY_HOST)/g; s/__redis_name__/$(REDIS_HOST)/g; s/__db_name__/$(DB_HOST)/g; s/__pgadmin_name__/$(PGADMIN_HOST)/g'
 
 default: build
 
@@ -12,3 +14,8 @@ run: build
 
 shell: build
 	docker run --rm -it $(DOCKER_TAG) /bin/bash
+
+rename:
+	$(REPLACE_NAMES) docker-compose.raw > docker-compose.yml
+	$(REPLACE_NAMES) docker-compose.dev.raw > docker-compose.dev.yml
+	$(REPLACE_NAMES) proxy/nginx.raw > proxy/nginx.conf

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 include librephotos.env
 DOCKER_TAG ?= ownphotos-backend
-REPLACE_NAMES=sed 's/__backend_name__/$(BACKEND_HOST)/g; s/__frontend_name__/$(FRONTEND_HOST)/g; s/__proxy_name__/$(PROXY_HOST)/g; s/__redis_name__/$(REDIS_HOST)/g; s/__db_name__/$(DB_HOST)/g; s/__pgadmin_name__/$(PGADMIN_HOST)/g'
+REPLACE_NAMES=sed 's/__backend_name__/$(BACKEND_CONT_NAME)/g; s/__frontend_name__/$(FRONTEND_CONT_NAME)/g; s/__proxy_name__/$(PROXY_CONT_NAME)/g; s/__redis_name__/$(REDIS_CONT_NAME)/g; s/__db_name__/$(DB_CONT_NAME)/g; s/__pgadmin_name__/$(PGADMIN_CONT_NAME)/g'
 
 default: build
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,10 @@ Follow the instructions [here](https://docs.librephotos.com/1/arm_install/)
 # For developers:
 Follow the instructions [here](https://docs.librephotos.com/1/dev_install/)
 
+# To use your own container names:
+Follow the normal instructions as per your chosen build, but after updating the `.env` file to choose your container names, run 
+``` sh
+make rename
+```
+Then you can resume following the normal instructions.
+

--- a/docker-compose.dev.raw
+++ b/docker-compose.dev.raw
@@ -1,0 +1,69 @@
+# Run options:
+# 1. There are no options - This add additional tools to aid in the development of Libre Photos
+#   run cmd: docker-compose up -f docker-compose.yml -f docker-compose.dev.yml -d
+# 2. Current added tools:
+#    pgadmin User admin@admin pass admin port 3001
+
+# DO NOT EDIT
+# The .env file has everything you need to edit.
+# Run options:
+# 1. Use prebuilt images (preferred method):
+#   run cmd: docker-compose up -d
+# 2. Build images on your own machine:
+#   build cmd: COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
+#   run cmd: docker-compose up -d
+
+version: '3.8'
+services:
+
+  __proxy_name__:
+    tty: true
+    build:
+      context: ./proxy
+      dockerfile: Dockerfile
+    volumes:
+      - ${myPhotos}:/data
+      - ${proMedia}:/protected_media
+      - ./proxy/nginx.conf:/etc/nginx/nginx.conf:ro
+
+  __frontend_name__:
+    tty: true
+    environment:
+    - DEBUG=1
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.dev
+    volumes:
+      - ${codedir}/librephotos-frontend:/usr/src/app
+
+  __backend_name__:
+    tty: true
+    stdin_open: true
+    environment:
+      - DEBUG=1
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+      args:
+        DEBUG: 1
+    volumes:
+      - ${myPhotos}:/data
+      - ${proMedia}:/protected_media
+      - ${logLocation}:/logs
+      - ${codedir}/librephotos:/code
+      - ${cachedir}:/root/.cache
+      - ./vscode/server-extensions:/root/.vscode-server/extensions
+      - ./vscode/server-insiders-extensions:/root/.vscode-server-insiders/extensions
+      - ./vscode/settings.json:/code/.vscode/settings.json
+      - ./backend/entrypoint.sh:/entrypoint.sh
+
+  __pgadmin_name__:
+    image: dpage/pgadmin4
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@admin.com}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+    volumes:
+       - $HOME/pgadmin:/root/.pgadmin
+    ports:
+      - "3001:80"
+    restart: unless-stopped

--- a/docker-compose.raw
+++ b/docker-compose.raw
@@ -58,7 +58,7 @@ services:
       - DB_NAME=${dbName}
       - DB_USER=${dbUser}
       - DB_PASS=${dbPass}
-      - DB_HOST=${DB_HOST}
+      - DB_HOST=${dbHost}
       - DB_PORT=5432
       - REDIS_HOST=__redis_name__
       - REDIS_PORT=6379

--- a/docker-compose.raw
+++ b/docker-compose.raw
@@ -15,6 +15,7 @@ services:
     volumes:
       - ${myPhotos}:/data
       - ${proMedia}:/protected_media
+      - ./proxy/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
       - ${httpPort}:80
     depends_on:
@@ -57,7 +58,7 @@ services:
       - DB_NAME=${dbName}
       - DB_USER=${dbUser}
       - DB_PASS=${dbPass}
-      - DB_HOST=${dbHost}
+      - DB_HOST=${DB_HOST}
       - DB_PORT=5432
       - REDIS_HOST=__redis_name__
       - REDIS_PORT=6379

--- a/docker-compose.raw
+++ b/docker-compose.raw
@@ -1,0 +1,77 @@
+# DO NOT EDIT
+# The .env file has everything you need to edit.
+# Run options:
+# 1. Use prebuilt images (preferred method):
+#   run cmd: docker-compose up -d
+# 2. Build images on your own machine:
+#   build cmd: COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 docker-compose build
+#   run cmd: docker-compose up -d
+
+version: "3.8"
+services:
+  __proxy_name__:
+    image: reallibrephotos/librephotos-proxy:${tag}
+    restart: always
+    volumes:
+      - ${myPhotos}:/data
+      - ${proMedia}:/protected_media
+    ports:
+      - ${httpPort}:80
+    depends_on:
+      - __backend_name__
+      - __frontend_name__
+
+  __db_name__:
+    image: postgres:13
+    restart: always
+    environment:
+      - POSTGRES_USER=${dbUser}
+      - POSTGRES_PASSWORD=${dbPass}
+      - POSTGRES_DB=${dbName}
+    volumes:
+      - ${dbLocation}:/var/lib/postgresql/data
+    command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off -c random_page_cost=1.0
+
+  __frontend_name__:
+    image: reallibrephotos/librephotos-frontend:${tag}
+    restart: always
+    depends_on:
+      - __backend_name__
+
+  __backend_name__:
+    image: reallibrephotos/librephotos:${tag}
+    restart: always
+    volumes:
+      - ${myPhotos}:/data
+      - ${proMedia}:/protected_media
+      - ${logLocation}:/logs
+      - ${cachedir}:/root/.cache
+
+    environment:
+      - SECRET_KEY=${shhhhKey}
+      - BACKEND_HOST=__backend_name__
+      - ADMIN_EMAIL=${adminEmail}
+      - ADMIN_USERNAME=${userName}
+      - ADMIN_PASSWORD=${userPass}
+      - DB_BACKEND=postgresql
+      - DB_NAME=${dbName}
+      - DB_USER=${dbUser}
+      - DB_PASS=${dbPass}
+      - DB_HOST=${dbHost}
+      - DB_PORT=5432
+      - REDIS_HOST=__redis_name__
+      - REDIS_PORT=6379
+      - MAPBOX_API_KEY=${mapApiKey}
+      - WEB_CONCURRENCY=${gunniWorkers}
+      - SKIP_PATTERNS=${skipPatterns}
+      - ALLOW_UPLOAD=${allowUpload}
+      - DEBUG=0
+      - HEAVYWEIGHT_PROCESS=${HEAVYWEIGHT_PROCESS}
+
+    # Wait for Postgres
+    depends_on:
+      - __db_name__
+
+  __redis_name__:
+    image: redis:6
+    restart: always

--- a/librephotos.env
+++ b/librephotos.env
@@ -31,9 +31,6 @@ userPass=admin
 # Email for the administrative user.
 adminEmail=admin@example.com
 
-# Database host. Only change this if you want to use your own existing Postgres server. If using your own server, you can remove the 'db' container from docker-compose.yml
-dbHost=db
-
 # Allow uploading files
 allowUpload=true
 
@@ -79,13 +76,12 @@ DEFAULT_FAVORITE_MIN_RATING=4
 
 # Set the names of the docker containers to your own entries. Or don't, I'm not your dad.
 # Changing these will require you to `make rename` to rename the services, and start the system with your chosen `docker-compose up -d` invocation again.
-SERVICE_PREFIX=
-BACKEND_HOST=$(SERVICE_PREFIX)backend
-FRONTEND_HOST=$(SERVICE_PREFIX)frontend
-PROXY_HOST=$(SERVICE_PREFIX)proxy
-REDIS_HOST=$(SERVICE_PREFIX)redis
-DB_HOST=$(SERVICE_PREFIX)db
-PGADMIN_HOST=$(SERVICE_PREFIX)pgadmin
+BACKEND_HOST=backend
+FRONTEND_HOST=frontend
+PROXY_HOST=proxy
+REDIS_HOST=redis
+DB_HOST=db
+PGADMIN_HOST=pgadmin
 
 # ---------------------------------------------------------------------------------------------
 

--- a/librephotos.env
+++ b/librephotos.env
@@ -77,6 +77,16 @@ HEAVYWEIGHT_PROCESS=1
 # Users can change this in their settings (Dashboards > Library).
 DEFAULT_FAVORITE_MIN_RATING=4
 
+# Set the names of the docker containers to your own entries. Or don't, I'm not your dad.
+# Changing these will require you to `make rename` to rename the services, and start the system with your chosen `docker-compose up -d` invocation again.
+SERVICE_PREFIX=
+BACKEND_HOST=$(SERVICE_PREFIX)backend
+FRONTEND_HOST=$(SERVICE_PREFIX)frontend
+PROXY_HOST=$(SERVICE_PREFIX)proxy
+REDIS_HOST=$(SERVICE_PREFIX)redis
+DB_HOST=$(SERVICE_PREFIX)db
+PGADMIN_HOST=$(SERVICE_PREFIX)pgadmin
+
 # ---------------------------------------------------------------------------------------------
 
 # If you are not a developer ignore the following parameters: you will never need them.

--- a/librephotos.env
+++ b/librephotos.env
@@ -31,6 +31,9 @@ userPass=admin
 # Email for the administrative user.
 adminEmail=admin@example.com
 
+# Database host. Only change this if you want to use your own existing Postgres server. If using your own server, you can remove the 'db' container from docker-compose.yml. If you're changing the name of the DB's container name (DB_CONT_NAME further down), you need to set this variable to match that name too.
+dbHost=db
+
 # Allow uploading files
 allowUpload=true
 
@@ -76,12 +79,13 @@ DEFAULT_FAVORITE_MIN_RATING=4
 
 # Set the names of the docker containers to your own entries. Or don't, I'm not your dad.
 # Changing these will require you to `make rename` to rename the services, and start the system with your chosen `docker-compose up -d` invocation again.
-BACKEND_HOST=backend
-FRONTEND_HOST=frontend
-PROXY_HOST=proxy
-REDIS_HOST=redis
-DB_HOST=db
-PGADMIN_HOST=pgadmin
+# Note that changing the DB_CONT_NAME will also need you to set the `dbHost` variable to the same value.
+DB_CONT_NAME=db
+BACKEND_CONT_NAME=backend
+FRONTEND_CONT_NAME=frontend
+PROXY_CONT_NAME=proxy
+REDIS_CONT_NAME=redis
+PGADMIN_CONT_NAME=pgadmin
 
 # ---------------------------------------------------------------------------------------------
 

--- a/proxy/nginx.raw
+++ b/proxy/nginx.raw
@@ -1,0 +1,55 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log debug;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+  server {
+    listen 80;
+    
+    location / {
+      # React routes are entirely on the App side in the web broswer
+      # Always proxy to root with the same page request when nginx 404s
+      error_page 404 /;
+      proxy_intercept_errors on;
+      proxy_set_header Host $host;
+      proxy_pass http://__frontend_name__:3000/;
+    }
+    location ~ ^/(api|media)/ {
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header Host __backend_name__;
+      include uwsgi_params;
+      proxy_pass http://__backend_name__:8001;
+    }
+    # Django media
+    location /protected_media  {
+        internal;
+        alias /protected_media/;      
+    }
+
+    location /static/drf-yasg {
+        proxy_pass http://__backend_name__:8001;  
+    }
+
+    location /data  {
+        internal;
+        alias /data/;      
+    }
+
+    # Original Photos
+    location /original  {
+        internal;
+        alias /data/;
+    }
+    # Nextcloud Original Photos
+    location /nextcloud_original  {
+        internal;
+        alias /data/nextcloud_media/;
+    }
+  }
+}


### PR DESCRIPTION
Added a `make rename` command to the Makefile that regenerates the:
* `docker-compose.yml`
* `docker-compose.dev.yml`
* `proxy/nginx.conf`
files to enable changing the names of the containers.

Should resolve #12.

By default it keeps the container names the same as they are already, but allows easier renaming.

Note that the `librephotos.env` has had the `dbHost` variable removed in favour of the `DB_HOST` variable and that the `nginx.conf` is now mounted as a read-only volume for both the dev build and for the production build.