### PR TITLE
add additional frontend run command to patch fomatnic-ui-css package

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /usr/src/app
 ENV CLI_WIDTH 80
 RUN git clone https://github.com/LibrePhotos/librephotos-frontend /usr/src/app
 RUN npm install --legacy-peer-deps
+RUN npm run postinstall
 RUN npm run build
 
 FROM halverneus/static-file-server


### PR DESCRIPTION
this additional step is required in the frontend-repo in order to apply the patches for the `fomantic-ui-css` package until the relevant PR is accepted 

  * https://github.com/fomantic/Fomantic-UI-CSS/pull/12
  * https://github.com/fomantic/Fomantic-UI-CSS/pull/13

However, that repo only gets updated once the main repo is updated. So this is a intermediate fix until we can upgrade `fomantic-ui-css`