### PR TITLE
fixed a small typo in env file

### DIFF
--- a/librephotos.env
+++ b/librephotos.env
@@ -1,6 +1,6 @@
 # This file contains all the things you need to change to set up your Libre Photos. 
 # There are a few items that must be set for it to work such as the location of your photos.
-# After the mandatory entry's there are some optional ones that you may set. 
+# After the mandatory entries there are some optional ones that you may set. 
 
 # Start of mandatory changes. 
 


### PR DESCRIPTION
Changed `entry's` to `entries` in the `librephotos.env` file.