### PR TITLE
Extended condition for depends_upon db

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,13 @@ services:
     volumes:
       - ${data}/db:/var/lib/postgresql/data
     command: postgres -c fsync=off -c synchronous_commit=off -c full_page_writes=off -c random_page_cost=1.0
-
+    #Checking health of Postgres db
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${dbUser}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      
   frontend:
     image: reallibrephotos/librephotos-frontend:${tag}
     container_name: frontend
@@ -74,7 +80,8 @@ services:
 
     # Wait for Postgres
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   redis:
     image: redis:6


### PR DESCRIPTION
A fix for issue #40 that does not touch 'entrypoint.sh' in the backend. Wait is directly implemented into the 'docker-compose.yml'.

Commit is self explanatory commit using https://stackoverflow.com/a/55835081

Checks health of Postgres db using pg_isready then moves onto creating the backend environment.

Maintainers, feel free to adjust the `interval`, `timeout`, and `reties` values.