### PR TITLE
Update to Jammy Jellyfish

### DIFF
--- a/backend/base/Dockerfile
+++ b/backend/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:hirsute
+FROM ubuntu:jammy
 ARG TARGETPLATFORM
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Hirsute Hippo is EOL and not secure anymore. 
When reverse proxying this docker it should be as secure as possible.
