### PR TITLE
Add automatic upgrades for all packages

### DIFF
--- a/backend/base/Dockerfile
+++ b/backend/base/Dockerfile
@@ -54,6 +54,20 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
     
+#  Add unattended-upgrade
+RUN apt-get update \
+  && apt-get install -y supervisor unattended-upgrades \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY supervisor-cron /supervisor-cron
+RUN chmod 755 supervisor-cron
+RUN /supervisor-cron
+
+COPY cronjob-upgrade /cronjob-upgrade
+RUN chmod 755 /cronjob-upgrade
+
+ENTRYPOINT ["/cronjob-upgrade"]
+
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then pip3 install --no-cache-dir torch torchvision -f https://torch.kmtea.eu/whl/stable.html; else pip3 install --no-cache-dir torch torchvision; fi
 
 RUN pip3 install --no-cache-dir pyvips==2.2.1 cmake==3.21.2

--- a/cronjob-upgrade
+++ b/cronjob-upgrade
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+#Run Task every midnight, edit cron expression to change
+echo "0 0 * * * root /usr/bin/unattended-upgrade" >> /etc/crontab
+echo "Cron supervisord started ..."
+
+exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/supervisor-cron
+++ b/supervisor-cron
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+cat > /etc/supervisor/conf.d/cron.conf <<EOF
+[program:cron]
+priority=20
+directory=/tmp
+command=/usr/sbin/cron -f
+user=root
+autostart=true
+autorestart=true
+stdout_logfile=/var/log/supervisor/%(program_name)s.log
+stderr_logfile=/var/log/supervisor/%(program_name)s.log
+EOF
+
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds automatic upgrade CRON jobs to keep all packages up-to-date.
Purpose is to ensure  security updates being installed automatically in production untill a new updated docker image is pushed and deployed with latest security updates.

Using unattended-upgrade and supervisor.
