### PR TITLE
Reduce docker layer size

### DIFF
--- a/backend/base/Dockerfile
+++ b/backend/base/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get update \
   && apt-get install -y python3-pip python3-dev \
   && cd /usr/local/bin \
   && ln -s /usr/bin/python3 python \
-  && pip3 install --upgrade pip
+  && pip3 install --upgrade pip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # system packages installation
 RUN apt-get update && \
@@ -66,7 +68,8 @@ RUN git clone https://github.com/LibRaw/LibRaw && \
 	autoreconf --install && \
 	./configure && \
 	make && \
-	make install
+	make install && \
+        rm -rf /tmp/builds/*
 
 #Build and install imagemagick
 WORKDIR /tmp/builds
@@ -75,7 +78,8 @@ RUN curl -SL https://imagemagick.org/archive/releases/ImageMagick-${IMAGEMAGICK_
 	cd ImageMagick-${IMAGEMAGICK_VERSION} && \
 	./configure --with-modules && \
 	make install && \
-	ldconfig /usr/local/lib
+	ldconfig /usr/local/lib && \
+        rm -rf /tmp/builds/*
 
 # Build and install libvips
 WORKDIR /tmp/builds
@@ -85,4 +89,5 @@ RUN curl -SL https://github.com/libvips/libvips/releases/download/v${VIPSVERSION
 	&& ./configure \ 
 	&& make V=0 \ 
 	&& make install \ 
-	&& ldconfig
+        && ldconfig \
+        && rm -rf /tmp/builds/*

--- a/backend/dependencies/Dockerfile
+++ b/backend/dependencies/Dockerfile
@@ -9,7 +9,8 @@ RUN git clone --depth 1 --branch 'v19.24' https://github.com/davisking/dlib.git 
     cmake .. -DDLIB_USE_CUDA=0 -DUSE_AVX_INSTRUCTIONS=0 -DLIB_NO_GUI_SUPPORT=0 && \
     cmake --build . && \
     cd /tmp/builds/dlib && \
-    python3 setup.py install --no USE_AVX_INSTRUCTIONS --no DLIB_USE_CUDA --no USE_SSE4_INSTRUCTIONS  
+    python3 setup.py install --no USE_AVX_INSTRUCTIONS --no DLIB_USE_CUDA --no USE_SSE4_INSTRUCTIONS && \
+    rm -rf /tmp/builds/* 
 
 # Download pretrained models
 WORKDIR /data_models
@@ -18,6 +19,3 @@ RUN mkdir -p /root/.cache/torch/hub/checkpoints/ && \
 	curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/im2txt.tar.gz | tar -zxC /data_models/ && \
 	curl -SL https://github.com/LibrePhotos/librephotos-docker/releases/download/0.1/clip-embeddings.tar.gz | tar -zxC /data_models/ && \
 	curl -SL https://download.pytorch.org/models/resnet152-b121ed2d.pth -o /root/.cache/torch/hub/checkpoints/resnet152-b121ed2d.pth
-
-# Remove build directory
-RUN rm -fr /tmp/*


### PR DESCRIPTION
Remove unneeded build files to reduce the size of the layers. It will reduce ~700Mb on average

To analyze the size of the layers you can build the Dockerfile `docker build my-tag .` and then, after the image is built, run the command `docker history my-tag`

Let me show `history` of the two updated Dockerfile files on this PR:

`backend/base/Dockerfile` (current repository version):
```
IMAGE          CREATED       CREATED BY                                      SIZE      COMMENT
fd27e3a2e969   3 hours ago   |2 IMAGEMAGICK_VERSION=7.1.0-48 VIPSVERSION=…   243MB     
94aed1f61010   3 hours ago   /bin/sh -c #(nop)  ARG VIPSVERSION=8.13.0       0B        
a40cebef451b   3 hours ago   /bin/sh -c #(nop) WORKDIR /tmp/builds           0B        
f76e7cf39d07   3 hours ago   |1 IMAGEMAGICK_VERSION=7.1.0-48 /bin/sh -c c…   307MB     
d08c9f197a78   3 hours ago   /bin/sh -c #(nop)  ARG IMAGEMAGICK_VERSION=7…   0B        
fda0f9ff862a   3 hours ago   /bin/sh -c #(nop) WORKDIR /tmp/builds           0B        
1da4f51ea743   3 hours ago   /bin/sh -c git clone https://github.com/LibR…   105MB     
2aa96d883938   3 hours ago   /bin/sh -c #(nop) WORKDIR /tmp/builds           0B        
f0fe6e1d811f   3 hours ago   /bin/sh -c pip3 install --no-cache-dir cmake…   47.1MB    
3b05f8304858   3 hours ago   /bin/sh -c if [ "$TARGETPLATFORM" = "linux/a…   3.49GB    
20dad66d591f   3 hours ago   /bin/sh -c apt-get update &&     apt-get ins…   1.47GB    
614273b47028   3 hours ago   /bin/sh -c apt-get update   && apt-get insta…   401MB     
605e9e569752   3 hours ago   /bin/sh -c #(nop)  ENV DEBIAN_FRONTEND=nonin…   0B        
acc76ef4351d   3 hours ago   /bin/sh -c #(nop)  ARG TARGETPLATFORM           0B        
a8780b506fa4   3 weeks ago   /bin/sh -c #(nop)  CMD ["bash"]                 0B        
<missing>      3 weeks ago   /bin/sh -c #(nop) ADD file:29c72d5be8c977aca…   77.8MB 
```

`backend/base/Dockerfile` (PR version):
```
IMAGE          CREATED             CREATED BY                                      SIZE      COMMENT
151378717430   About an hour ago   |2 IMAGEMAGICK_VERSION=7.1.0-48 VIPSVERSION=…   49.9MB    
6adcf397da80   About an hour ago   /bin/sh -c #(nop)  ARG VIPSVERSION=8.13.0       0B        
dadc7b964287   About an hour ago   /bin/sh -c #(nop) WORKDIR /tmp/builds           0B        
aaabeb6e5540   About an hour ago   |1 IMAGEMAGICK_VERSION=7.1.0-48 /bin/sh -c c…   68.8MB    
383a28845654   2 hours ago         /bin/sh -c #(nop)  ARG IMAGEMAGICK_VERSION=7…   0B        
5e83773dee8e   2 hours ago         /bin/sh -c #(nop) WORKDIR /tmp/builds           0B        
5790ead70e64   2 hours ago         /bin/sh -c git clone https://github.com/LibR…   29.9MB    
1ddad30f1ee8   2 hours ago         /bin/sh -c #(nop) WORKDIR /tmp/builds           0B        
29788c7f6637   2 hours ago         /bin/sh -c pip3 install --no-cache-dir cmake…   47.1MB    
6975b9ea99f1   2 hours ago         /bin/sh -c if [ "$TARGETPLATFORM" = "linux/a…   3.49GB    
43046782739a   2 hours ago         /bin/sh -c apt-get update &&     apt-get ins…   1.47GB    
a9e05f6ebead   2 hours ago         /bin/sh -c apt-get update   && apt-get insta…   361MB     
605e9e569752   3 hours ago         /bin/sh -c #(nop)  ENV DEBIAN_FRONTEND=nonin…   0B        
acc76ef4351d   3 hours ago         /bin/sh -c #(nop)  ARG TARGETPLATFORM           0B        
a8780b506fa4   3 weeks ago         /bin/sh -c #(nop)  CMD ["bash"]                 0B        
<missing>      3 weeks ago         /bin/sh -c #(nop) ADD file:29c72d5be8c977aca…   77.8MB 
```

===========================================================================

`/backend/dependencies/Dockerfile` (current repository version):
```
IMAGE          CREATED             CREATED BY                                      SIZE      COMMENT
819a25fb5e67   54 minutes ago      /bin/sh -c rm -fr /tmp/*                        0B        
7913bcb8a9ec   54 minutes ago      /bin/sh -c mkdir -p /root/.cache/torch/hub/c…   961MB     
fd4b4fc7bcba   56 minutes ago      /bin/sh -c #(nop) WORKDIR /data_models          0B        
be1520520f27   56 minutes ago      /bin/sh -c git clone --depth 1 --branch 'v19…   143MB     
0a462905d90d   About an hour ago   /bin/sh -c #(nop) WORKDIR /tmp/builds           0B        
3292236dcc73   2 months ago        RUN |3 TARGETPLATFORM=linux/amd64 IMAGEMAGIC…   243MB     buildkit.dockerfile.v0
<missing>      2 months ago        ARG VIPSVERSION=8.13.0                          0B        buildkit.dockerfile.v0
<missing>      2 months ago        WORKDIR /tmp/builds                             0B        buildkit.dockerfile.v0
<missing>      2 months ago        RUN |2 TARGETPLATFORM=linux/amd64 IMAGEMAGIC…   307MB     buildkit.dockerfile.v0
<missing>      2 months ago        ARG IMAGEMAGICK_VERSION=7.1.0-48                0B        buildkit.dockerfile.v0
<missing>      2 months ago        WORKDIR /tmp/builds                             0B        buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   105MB     buildkit.dockerfile.v0
<missing>      2 months ago        WORKDIR /tmp/builds                             0B        buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   47.1MB    buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   1.78GB    buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   1.35GB    buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   398MB     buildkit.dockerfile.v0
<missing>      2 months ago        ENV DEBIAN_FRONTEND=noninteractive              0B        buildkit.dockerfile.v0
<missing>      2 months ago        ARG TARGETPLATFORM                              0B        buildkit.dockerfile.v0
<missing>      2 months ago        /bin/sh -c #(nop)  CMD ["bash"]                 0B        
<missing>      2 months ago        /bin/sh -c #(nop) ADD file:a7268f82a86219801…   77.8MB
```

`/backend/dependencies/Dockerfile` (PR version):
```
IMAGE          CREATED             CREATED BY                                      SIZE      COMMENT
e1dcb9d6c269   17 minutes ago      /bin/sh -c mkdir -p /root/.cache/torch/hub/c…   961MB     
a52bc077e25c   35 minutes ago      /bin/sh -c #(nop) WORKDIR /data_models          0B        
ea0f55eb5fd5   35 minutes ago      /bin/sh -c git clone --depth 1 --branch 'v19…   11.8MB    
0a462905d90d   About an hour ago   /bin/sh -c #(nop) WORKDIR /tmp/builds           0B        
3292236dcc73   2 months ago        RUN |3 TARGETPLATFORM=linux/amd64 IMAGEMAGIC…   243MB     buildkit.dockerfile.v0
<missing>      2 months ago        ARG VIPSVERSION=8.13.0                          0B        buildkit.dockerfile.v0
<missing>      2 months ago        WORKDIR /tmp/builds                             0B        buildkit.dockerfile.v0
<missing>      2 months ago        RUN |2 TARGETPLATFORM=linux/amd64 IMAGEMAGIC…   307MB     buildkit.dockerfile.v0
<missing>      2 months ago        ARG IMAGEMAGICK_VERSION=7.1.0-48                0B        buildkit.dockerfile.v0
<missing>      2 months ago        WORKDIR /tmp/builds                             0B        buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   105MB     buildkit.dockerfile.v0
<missing>      2 months ago        WORKDIR /tmp/builds                             0B        buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   47.1MB    buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   1.78GB    buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   1.35GB    buildkit.dockerfile.v0
<missing>      2 months ago        RUN |1 TARGETPLATFORM=linux/amd64 /bin/sh -c…   398MB     buildkit.dockerfile.v0
<missing>      2 months ago        ENV DEBIAN_FRONTEND=noninteractive              0B        buildkit.dockerfile.v0
<missing>      2 months ago        ARG TARGETPLATFORM                              0B        buildkit.dockerfile.v0
<missing>      2 months ago        /bin/sh -c #(nop)  CMD ["bash"]                 0B        
<missing>      2 months ago        /bin/sh -c #(nop) ADD file:a7268f82a86219801…   77.8MB
```

Apart of that, the layer that [this line](https://github.com/LibrePhotos/librephotos-docker/blob/main/backend/base/Dockerfile#L13) creates could be reduced if we only install dependencies when needed. Maybe we could use a multi-stage docker build where "build dependencies" are only installed on the "builder image", and then the "binary" is copied and installed on the "final image", a similar approach is done on `frontend` service.

Lastly, I am not good with `pip` and `python`, but maybe the layer that [this line](https://github.com/LibrePhotos/librephotos-docker/blob/main/backend/base/Dockerfile#L57) creates can be improved by a similar approach (Removing any unneeded file it makes)