### PR TITLE
do not install CUDA dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,15 @@ REPLACE_NAMES=sed 's/__backend_name__/$(BACKEND_CONT_NAME)/g; s/__frontend_name_
 
 default: build
 
+build-dev: build-base build-dependencies
+
 build: build-backend build-frontend build-proxy
+
+build-base:
+	docker build -t reallibrephotos/librephotos-base:dev backend/base --no-cache
+
+build-dependencies:
+	docker build -t reallibrephotos/librephotos-dependencies:dev backend/dependencies --no-cache
 
 build-backend:
 	docker build -t reallibrephotos/librephotos:latest backend

--- a/backend/base/Dockerfile
+++ b/backend/base/Dockerfile
@@ -56,7 +56,12 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
     
-RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then pip3 install --no-cache-dir torch torchvision -f https://torch.kmtea.eu/whl/stable.html; else pip3 install --no-cache-dir torch torchvision; fi
+RUN \
+if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+  pip3 install --no-cache-dir torch torchvision -f https://torch.kmtea.eu/whl/stable.html; \
+else \
+  pip3 install --no-cache-dir torch torchvision --extra-index-url https://download.pytorch.org/whl/cpu; \
+fi
 
 RUN pip3 install --no-cache-dir cmake==3.21.2
 


### PR DESCRIPTION
Because we are using CPU for AI work, we don't need to install CUDA dependencies which takes considerable amount of disk space with no reason. This change reduce image size (for x86_64) by 2.6 GB.

Tested by scanning fresh installation with 4.5k photos. Face detection and scene detection worked fine.

Before applying changes:
```
reallibrephotos/librephotos                latest     c50f15649b37   29 hours ago        7.3GB
reallibrephotos/librephotos-dependencies   dev        6903e652f43a   4 weeks ago         6.57GB
reallibrephotos/librephotos-base           dev        75c120a59221   4 weeks ago         5.6GB
```
After applying changes:
```
reallibrephotos/librephotos                latest     74005f3a6941   15 minutes ago      4.68GB
reallibrephotos/librephotos-dependencies   dev        552a79c4b474   18 minutes ago      3.95GB
reallibrephotos/librephotos-base           dev        574018ce1df0   25 minutes ago      2.97GB
```