### PR TITLE
Removes extraneous call to mkdir

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,6 +1,5 @@
 FROM node:13-slim
 
-RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 RUN apt-get update && apt-get install git curl -y
 EXPOSE 3000


### PR DESCRIPTION
Trying to build and bring up librephotos with

```
docker-compose -f docker-compose.yml -f docker-compose.dev.yml build
docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
```

is failing with errors like

```
frontend  | sh: 1: patch-package: not found
frontend  | npm ERR! code ELIFECYCLE
frontend  | npm ERR! syscall spawn
frontend  | npm ERR! file sh
frontend  | npm ERR! errno ENOENT
frontend  | npm ERR! librephotos-frontend@0.1.0 postinstall: `patch-package`
frontend  | npm ERR! spawn ENOENT
```

Removing the extraneous call to `mkdir` resolved the issue for me.