### PR TITLE
fix k8s proxy config

### DIFF
--- a/docker-compose.e2e.raw
+++ b/docker-compose.e2e.raw
@@ -13,9 +13,7 @@ services:
     image: reallibrephotos/librephotos-proxy:${tag}
     container_name: e2e-__proxy_name__
     restart: unless-stopped
-    environment:
-      BACKEND_NAME: e2e-__backend_name__
-      FRONTEND_NAME: e2e-__frontend_name__
+    command: /bin/bash -c "sed -ri 's/(__backend_name__|__frontend_name__)/e2e-\1/' /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
     volumes:
       - e2e_scan_directory:/data
       - e2e_protected_media:/protected_media

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -13,9 +13,7 @@ services:
     image: reallibrephotos/librephotos-proxy:${tag}
     container_name: e2e-proxy
     restart: unless-stopped
-    environment:
-      BACKEND_NAME: e2e-backend
-      FRONTEND_NAME: e2e-frontend
+    command: /bin/bash -c "sed -ri 's/(backend|frontend)/e2e-\1/' /etc/nginx/nginx.conf && nginx -g 'daemon off;'"
     volumes:
       - e2e_scan_directory:/data
       - e2e_protected_media:/protected_media

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,6 +1,2 @@
 FROM nginx
-ENV BACKEND_NAME=${BACKEND_NAME:-backend}
-ENV FRONTEND_NAME=${FRONTEND_NAME:-frontend}
-ENV VAR_PREFIX='$'
-COPY nginx.tpl /etc/nginx/nginx.tpl
-ENTRYPOINT envsubst < /etc/nginx/nginx.tpl > /etc/nginx/nginx.conf; nginx -g 'daemon off;'
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -16,21 +16,21 @@ http {
       # Always proxy to root with the same page request when nginx 404s
       error_page 404 /;
       proxy_intercept_errors on;
-      proxy_set_header Host ${VAR_PREFIX}host;
-      proxy_pass http://${FRONTEND_NAME}:3000/;
+      proxy_set_header Host $host;
+      proxy_pass http://frontend:3000/;
     }
     location ~ ^/(api|media)/ {
-      proxy_set_header X-Forwarded-Proto ${VAR_PREFIX}scheme;
-      proxy_set_header X-Real-IP ${VAR_PREFIX}remote_addr;
-      proxy_set_header Host ${BACKEND_NAME};
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header Host backend;
       include uwsgi_params;
-      proxy_pass http://${BACKEND_NAME}:8001;
+      proxy_pass http://backend:8001;
     }
     # needed for webpack-dev-server
     location /ws {
-      proxy_pass http://${FRONTEND_NAME}:3000;
+      proxy_pass http://frontend:3000;
       proxy_http_version 1.1;
-      proxy_set_header Upgrade ${VAR_PREFIX}http_upgrade;
+      proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
     # Django media
@@ -40,7 +40,7 @@ http {
     }
 
     location /static/drf-yasg {
-        proxy_pass http://${BACKEND_NAME}:8001;
+        proxy_pass http://backend:8001;
     }
 
     location /data  {


### PR DESCRIPTION
Fixes #87

- restore proxy nginx.conf and Dockerfile as it was before e2e change
- when starting e2e replace inplace backend and frontend hostnames