### PR TITLE
fix rename function for proxy, ditch archived repository

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: default build rename
 
-include librephotos.env
+include .env
 REPLACE_NAMES=sed 's/__backend_name__/$(BACKEND_CONT_NAME)/g; s/__frontend_name__/$(FRONTEND_CONT_NAME)/g; s/__proxy_name__/$(PROXY_CONT_NAME)/g; s/__redis_name__/$(REDIS_CONT_NAME)/g; s/__db_name__/$(DB_CONT_NAME)/g; s/__pgadmin_name__/$(PGADMIN_CONT_NAME)/g; s/__network_name__/$(NETWORK_NAME)/g'
 
 default: build
@@ -28,3 +28,4 @@ rename:
 	$(REPLACE_NAMES) docker-compose.raw > docker-compose.yml
 	$(REPLACE_NAMES) docker-compose.dev.raw > docker-compose.dev.yml
 	$(REPLACE_NAMES) docker-compose.e2e.raw > docker-compose.e2e.yml
+	$(REPLACE_NAMES) proxy/nginx.raw > proxy/nginx.conf

--- a/docker-compose.raw
+++ b/docker-compose.raw
@@ -10,7 +10,10 @@
 version: "3.8"
 services:
   __proxy_name__:
-    image: reallibrephotos/librephotos-proxy:${tag}
+    tty: true
+    build:
+      context: ./proxy
+      dockerfile: Dockerfile
     container_name: __proxy_name__
     restart: unless-stopped
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@
 version: "3.8"
 services:
   proxy:
-    image: reallibrephotos/librephotos-proxy:${tag}
+    tty: true
+    build:
+      context: ./proxy
+      dockerfile: Dockerfile
     container_name: proxy
     restart: unless-stopped
     volumes:

--- a/librephotos.env
+++ b/librephotos.env
@@ -45,6 +45,7 @@ dbHost=db
 # Set the names of the docker containers to your own entries. Or don't, I'm not your dad.
 # Changing these will require you to `make rename` to rename the services, and start the system with your chosen `docker-compose up -d` invocation again.
 # Note that changing the DB_CONT_NAME will also need you to set the `dbHost` variable to the same value.
+# Note also that frontend and backend in particular must be compatible with RFC1035 (only allows for numbers, letters, and hyphens) because these will be url-proxy names that the proxy container will use to interact with the respective containers
 DB_CONT_NAME=db
 BACKEND_CONT_NAME=backend
 FRONTEND_CONT_NAME=frontend

--- a/proxy/nginx.raw
+++ b/proxy/nginx.raw
@@ -1,0 +1,62 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log debug;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+  server {
+    listen 80;
+    
+    location / {
+      # React routes are entirely on the App side in the web browser
+      # Always proxy to root with the same page request when nginx 404s
+      error_page 404 /;
+      proxy_intercept_errors on;
+      proxy_set_header Host $host;
+      proxy_pass http://__frontend_name__:3000/;
+    }
+    location ~ ^/(api|media)/ {
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header Host __backend_name__;
+      include uwsgi_params;
+      proxy_pass http://__backend_name__:8001;
+    }
+    # needed for webpack-dev-server
+    location /ws {
+      proxy_pass http://__frontend_name__:3000;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+    # Django media
+    location /protected_media  {
+        internal;
+        alias /protected_media/;      
+    }
+
+    location /static/drf-yasg {
+        proxy_pass http://__backend_name__:8001;
+    }
+
+    location /data  {
+        internal;
+        alias /data/;      
+    }
+
+    # Original Photos
+    location /original  {
+        internal;
+        alias /data/;
+    }
+    # Nextcloud Original Photos
+    location /nextcloud_original  {
+        internal;
+        alias /data/nextcloud_media/;
+    }
+  }
+}


### PR DESCRIPTION
So, I understand why you would by default set your frontend container's name to `frontend` and backend to `backend` etc. but what about those among us who are running more than one set of services on the same machine with other docker images/containers?  How's a guy to know, for example, which frontend `frontend` is?  By renaming to e.g. `librephotos-frontend` of course.

Only, when I tried that, it catastrophically failed (as most simple name reference disconnects do), and the [LibrePhotos/librephotos-proxy](https://github.com/LibrePhotos/librephotos-proxy) repo being archived as it is, I pivoted the setup to use the [proxy folder](https://github.com/LibrePhotos/librephotos-docker/tree/main/proxy) you guys already use for development, instead of the defunct standalone image repo for proxy.

Also the official docs tell us to copy `librephotos.env` to `.env` and edit.  Cool, only, you're not using that file in the rename function... so, fixed that.

With that sorted, seems to be running great so far, so kudos to a project well done!