### PR TITLE
Use `curl` rather than `git` to download repositories

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,7 +2,7 @@ FROM reallibrephotos/librephotos-base:dev
 # actual project
 ARG DEBUG
 WORKDIR /code
-RUN git clone --depth 1 https://github.com/LibrePhotos/librephotos .
+RUN curl -SL https://github.com/LibrePhotos/librephotos/archive/refs/heads/dev.tar.gz | tar --strip-components=1 -zxC .
 RUN pip install --break-system-packages --no-cache-dir -r requirements.txt
 RUN if [ "$DEBUG" = 1 ] ; then \
   pip install --break-system-packages -r requirements.dev.txt; \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,9 @@
 FROM node:18-slim as builder
 
-RUN apt-get update && apt-get install -y git
-
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 ENV CLI_WIDTH 80
-RUN git clone https://github.com/LibrePhotos/librephotos-frontend /usr/src/app
+RUN curl -SL https://github.com/LibrePhotos/librephotos-frontend/archive/refs/heads/dev.tar.gz | tar --strip-components=1 -zxC .
 RUN npm install --legacy-peer-deps
 RUN npm run postinstall
 RUN npm run build


### PR DESCRIPTION
Curl is much more efficient, and faster