### PR TITLE
allow to download photo archive without routing to backend

### DIFF
--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -22,6 +22,11 @@ http {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
+    # Allow to download zip files directly. This has to go before the following rule
+    location ~ ^/api/downloads/(.*)$ {
+      root /;
+      try_files /protected_media/zip/$1.zip =404;
+    }
     location ~ ^/(api|media)/ {
       proxy_set_header X-Forwarded-Proto $scheme;
       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
This is needed for refactored UI, where we would download a created archive of photos using nginx instead of going through the backend (ref:|https://github.com/LibrePhotos/librephotos-frontend/pull/527)

Same as the current endpoint for downloading archive, it skips the authentication. Maybe in the future we would have to route it again through the backend when we will decide that we want to use authentication for downloading photo archive.