### PR TITLE
refactor compose configs

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -1,0 +1,78 @@
+# DO NOT EDIT
+# The .env file has everything you need to edit.
+# Run options:
+# 1. Use prebuilt images (preferred method):
+#   run cmd: docker compose up -d
+# 2. Build images on your own machine:
+#   build cmd: docker compose build
+#   run cmd: docker compose up -d
+
+services:
+  proxy:
+    image: reallibrephotos/librephotos-proxy:${tag}
+    container_name: proxy
+    restart: unless-stopped
+    volumes:
+      - ${scanDirectory}:/data
+      - ${data}/protected_media:/protected_media
+    ports:
+      - ${httpPort}:80
+    healthcheck:
+      test: curl --fail http://localhost:80
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+  db:
+    image: pgautoupgrade/pgautoupgrade:latest
+    container_name: db
+    restart: unless-stopped
+    environment:
+      - POSTGRES_USER=${dbUser}
+      - POSTGRES_PASSWORD=${dbPass}
+      - POSTGRES_DB=${dbName}
+    volumes:
+      - ${data}/db:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -U ${dbUser} -d ${dbName}
+      interval: 3s
+      timeout: 3s
+      retries: 10
+
+  frontend:
+    image: reallibrephotos/librephotos-frontend:${tag}
+    container_name: frontend
+    restart: unless-stopped
+
+  backend:
+    image: reallibrephotos/librephotos:${tag}
+    container_name: backend
+    restart: unless-stopped
+    volumes:
+      - ${scanDirectory}:/data
+      - ${data}/protected_media:/protected_media
+      - ${data}/logs:/logs
+      - ${data}/cache:/root/.cache
+    environment:
+      - SECRET_KEY=${shhhhKey:-}
+      - BACKEND_HOST=backend
+      - ADMIN_EMAIL=${adminEmail:-}
+      - ADMIN_USERNAME=${userName:-}
+      - ADMIN_PASSWORD=${userPass:-}
+      - DB_BACKEND=postgresql
+      - DB_NAME=${dbName}
+      - DB_USER=${dbUser}
+      - DB_PASS=${dbPass}
+      - DB_HOST=${dbHost}
+      - DB_PORT=5432
+      - MAPBOX_API_KEY=${mapApiKey:-}
+      - WEB_CONCURRENCY=${gunniWorkers:-1}
+      - SKIP_PATTERNS=${skipPatterns:-}
+      - ALLOW_UPLOAD=${allowUpload:-false}
+      - CSRF_TRUSTED_ORIGINS=${csrfTrustedOrigins:-}
+      - DEBUG=0
+    healthcheck:
+      test: curl --fail http://localhost:8001/api/schema
+      interval: 3s
+      timeout: 3s
+      retries: 10

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,6 +15,9 @@
 
 services:
   proxy:
+    extends:
+      file: docker-compose.base.yml
+      service: proxy
     tty: true
     build:
       context: ./proxy
@@ -23,8 +26,16 @@ services:
     volumes:
       - ${scanDirectory}:/data
       - ${data}/protected_media:/protected_media
+    depends_on:
+      frontend:
+        condition: service_healthy
+      backend:
+        condition: service_healthy
 
   frontend:
+    extends:
+      file: docker-compose.base.yml
+      service: frontend
     tty: true
     environment:
       - DEBUG=1
@@ -35,8 +46,16 @@ services:
     container_name: frontend
     volumes:
       - ${codedir}/librephotos-frontend:/usr/src/app
+    healthcheck:
+      test: curl --fail http://localhost:3000
+      interval: 3s
+      timeout: 3s
+      retries: 10
 
   backend:
+    extends:
+      file: docker-compose.base.yml
+      service: backend
     tty: true
     stdin_open: true
     environment:
@@ -57,6 +76,14 @@ services:
       - ./vscode/server-insiders-extensions:/root/.vscode-server-insiders/extensions
       - ./vscode/settings.json:/code/.vscode/settings.json
       - ./backend/entrypoint.sh:/entrypoint.sh
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    extends:
+      file: docker-compose.base.yml
+      service: db
 
   pgadmin:
     image: dpage/pgadmin4
@@ -64,6 +91,7 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@admin.com}
       PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin}
+      DEFAULT_THEME: dark
     volumes:
       - ${pgAdminLocation}/pgadmin:/root/.pgadmin
     ports:

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -42,7 +42,7 @@ services:
     volumes:
       - ${e2e_bootstrap_dir:-./e2e}/init.sql.gz:/docker-entrypoint-initdb.d/init.sql.gz
     healthcheck:
-      test: psql -U ${dbUser} -d ${dbName} -c "SELECT 1;"
+      test: pg_isready -U ${dbUser} -d ${dbName}
       interval: 5s
       timeout: 5s
       retries: 12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,66 +9,32 @@
 
 services:
   proxy:
-    image: reallibrephotos/librephotos-proxy:${tag}
-    container_name: proxy
-    restart: unless-stopped
-    volumes:
-      - ${scanDirectory}:/data
-      - ${data}/protected_media:/protected_media
-    ports:
-      - 3000:80
+    extends:
+      file: docker-compose.base.yml
+      service: proxy
     depends_on:
-      - backend
-      - frontend
+      backend:
+        condition: service_healthy
+      frontend:
+        condition: service_started
 
   db:
-    image: pgautoupgrade/pgautoupgrade:latest
-    container_name: db
-    restart: unless-stopped
-    environment:
-      - POSTGRES_USER=${dbUser}
-      - POSTGRES_PASSWORD=${dbPass}
-      - POSTGRES_DB=${dbName}
-    volumes:
-      - ${data}/db:/var/lib/postgresql/data
-    healthcheck:
-      test: psql -U ${dbUser} -d ${dbName} -c "SELECT 1;"
-      interval: 5s
-      timeout: 5s
-      retries: 5
+    extends:
+      file: docker-compose.base.yml
+      service: db
+    depends_on:
+      db:
+        condition: service_healthy
 
   frontend:
-    image: reallibrephotos/librephotos-frontend:${tag}
-    container_name: frontend
-    restart: unless-stopped
+    extends:
+      file: docker-compose.base.yml
+      service: frontend
 
   backend:
-    image: reallibrephotos/librephotos:${tag}
-    container_name: backend
-    restart: unless-stopped
-    volumes:
-      - ${scanDirectory}:/data
-      - ${data}/protected_media:/protected_media
-      - ${data}/logs:/logs
-      - ${data}/cache:/root/.cache
-    environment:
-      - SECRET_KEY=${shhhhKey:-}
-      - BACKEND_HOST=backend
-      - ADMIN_EMAIL=${adminEmail:-}
-      - ADMIN_USERNAME=${userName:-}
-      - ADMIN_PASSWORD=${userPass:-}
-      - DB_BACKEND=postgresql
-      - DB_NAME=${dbName}
-      - DB_USER=${dbUser}
-      - DB_PASS=${dbPass}
-      - DB_HOST=${dbHost}
-      - DB_PORT=5432
-      - MAPBOX_API_KEY=${mapApiKey:-}
-      - WEB_CONCURRENCY=${gunniWorkers:-1}
-      - SKIP_PATTERNS=${skipPatterns:-}
-      - ALLOW_UPLOAD=${allowUpload:-false}
-      - CSRF_TRUSTED_ORIGINS=${csrfTrustedOrigins:-}
-      - DEBUG=0
+    extends:
+      file: docker-compose.base.yml
+      service: backend
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
- Use/extend base compose file for prod and dev configs. This allow to (re-)run dev environment by providing only dev config file.
- Take into account httpPort variable. Fixes https://github.com/LibrePhotos/librephotos-docker/issues/130 