### PR TITLE
Remove redundant SQLite data directory creation

### DIFF
--- a/unified/entrypoint.sh
+++ b/unified/entrypoint.sh
@@ -26,9 +26,6 @@ DB_BACKEND=${DB_BACKEND:-sqlite}
 
 if [ "$DB_BACKEND" = "sqlite" ]; then
     echo "Using production-optimized SQLite database mode"
-    # Ensure database directory exists
-    mkdir -p /data/db
-    
     # Run migrations for both default and cache databases
     python manage.py migrate
     


### PR DESCRIPTION
## Summary
- remove the entrypoint's creation of /data/db for SQLite deployments since the Django settings already manage the database directory
- prevent failures when the /data volume is mounted read-only as recommended by the docs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907b11b679c83278993302ac8fb308e